### PR TITLE
Add VarMultiset and ArcVarMultisetVisitor

### DIFF
--- a/include/PetriEngine/Colored/ArcVarMultisetVisitor.h
+++ b/include/PetriEngine/Colored/ArcVarMultisetVisitor.h
@@ -1,0 +1,91 @@
+/*
+ * Authors:
+ *      Nicolaj Østerby Jensen
+ *      Jesper Adriaan van Diepen
+ *      Mathias Mehl Sørensen
+ */
+
+#ifndef VERIFYPN_ARCVARMULTISETVISITOR_H
+#define VERIFYPN_ARCVARMULTISETVISITOR_H
+
+#include <utils/errors.h>
+#include "Expressions.h"
+#include "ColorExpressionVisitor.h"
+#include "VarMultiset.h"
+
+namespace PetriEngine::Colored {
+    class ArcVarMultisetVisitor : ColorExpressionVisitor {
+    public:
+        ArcVarMultisetVisitor() : _mres() {}
+
+        void accept(const DotConstantExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const VariableExpression *) override;
+
+        void accept(const UserOperatorExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const SuccessorExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const PredecessorExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const TupleExpression *) override;
+
+        void accept(const LessThanExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const LessThanEqExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const EqualityExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const InequalityExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const AndExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const OrExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const AllExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const NumberOfExpression *) override;
+
+        void accept(const AddExpression *) override;
+
+        void accept(const SubtractExpression *) override {
+            _ok = false;
+        };
+
+        void accept(const ScalarProductExpression *) override;
+
+        [[nodiscard]] bool ok() const {
+            return _ok;
+        }
+
+        static VarMultiset extract(const ArcExpression &e);
+
+    private:
+        bool _ok = true; // False if the arc expression could not be converted to multiset of variables
+        VarMultiset _mres;
+    };
+}
+
+#endif //VERIFYPN_ARCVARMULTISETVISITOR_H

--- a/include/PetriEngine/Colored/ArcVarMultisetVisitor.h
+++ b/include/PetriEngine/Colored/ArcVarMultisetVisitor.h
@@ -16,7 +16,7 @@
 namespace PetriEngine::Colored {
     class ArcVarMultisetVisitor : ColorExpressionVisitor {
     public:
-        ArcVarMultisetVisitor() : _msRes(), _tupRes(), _varRes {};
+        ArcVarMultisetVisitor() : _msRes(), _tupRes(), _varRes() {};
 
         void accept(const DotConstantExpression *) override {
             _ok = false;
@@ -80,7 +80,7 @@ namespace PetriEngine::Colored {
             return _ok;
         }
 
-        static VarMultiset extract(const ArcExpression &e);
+        static std::optional<VarMultiset> extract(const ArcExpression &e);
 
     private:
         bool _ok = true; // False if the arc expression could not be converted to multiset of variables

--- a/include/PetriEngine/Colored/ArcVarMultisetVisitor.h
+++ b/include/PetriEngine/Colored/ArcVarMultisetVisitor.h
@@ -16,7 +16,7 @@
 namespace PetriEngine::Colored {
     class ArcVarMultisetVisitor : ColorExpressionVisitor {
     public:
-        ArcVarMultisetVisitor() : _mres() {}
+        ArcVarMultisetVisitor() : _msRes(), _tupRes(), _varRes {};
 
         void accept(const DotConstantExpression *) override {
             _ok = false;
@@ -84,7 +84,10 @@ namespace PetriEngine::Colored {
 
     private:
         bool _ok = true; // False if the arc expression could not be converted to multiset of variables
-        VarMultiset _mres;
+        VarMultiset _msRes;
+        bool _inTuple = false;
+        std::vector<const Variable *> _tupRes;
+        const Variable * _varRes;
     };
 }
 

--- a/include/PetriEngine/Colored/VarMultiset.h
+++ b/include/PetriEngine/Colored/VarMultiset.h
@@ -17,20 +17,19 @@ namespace PetriEngine::Colored {
     private:
         class Iterator;
 
-        typedef std::vector<std::pair<const Variable *, uint32_t>> Internal;
+        typedef std::vector<const Variable *> VarTuple;
+        typedef std::vector<std::pair<VarTuple, uint32_t>> Internal;
 
         Internal _set;
-        const ColorType *_type;
+        std::vector<const ColorType *> _types;
     public:
-        VarMultiset() : _set(), _type(nullptr) {};
+        VarMultiset() : _set(), _types() {};
 
-        VarMultiset(const ColorType *type) : _set(), _type(type) {};
+        VarMultiset(std::vector<const ColorType *> &types) : _set(), _types(types) {};
 
         VarMultiset(const VarMultiset &) = default;
 
         VarMultiset(VarMultiset &&) = default;
-
-        VarMultiset(const Variable *, uint32_t);
 
         ~VarMultiset() = default;
 
@@ -54,9 +53,9 @@ namespace PetriEngine::Colored {
 
         void operator*=(uint32_t scalar);
 
-        uint32_t operator[](const Variable *color) const;
+        uint32_t operator[](const VarTuple &vt) const;
 
-        uint32_t &operator[](const Variable *color);
+        uint32_t &operator[](const VarTuple &vt);
 
         bool isSubsetOf(const VarMultiset &other) const;
 
@@ -70,9 +69,18 @@ namespace PetriEngine::Colored {
             return _set.size();
         }
 
+        size_t tupleSize() const {
+            return _types.size();
+        }
+
         std::string toString() const;
 
     private:
+
+        bool matchesType(const VarTuple &vt) const;
+
+        std::vector<const ColorType *> inferTypes(const VarTuple &vt);
+
         class Iterator {
         private:
             const VarMultiset *_ms;
@@ -88,9 +96,9 @@ namespace PetriEngine::Colored {
 
             Iterator &operator++();
 
-            std::pair<const Variable *, const uint32_t &> operator++(int);
+            std::pair<const std::vector<const Variable *>, const uint32_t &> operator++(int);
 
-            std::pair<const Variable *, const uint32_t &> operator*();
+            std::pair<const std::vector<const Variable *>, const uint32_t &> operator*();
         };
     };
 }

--- a/include/PetriEngine/Colored/VarMultiset.h
+++ b/include/PetriEngine/Colored/VarMultiset.h
@@ -27,6 +27,8 @@ namespace PetriEngine::Colored {
 
         VarMultiset(std::vector<const ColorType *> &types) : _set(), _types(types) {};
 
+        VarMultiset(const VarTuple &vars, uint32_t multiplicity);
+
         VarMultiset(const VarMultiset &) = default;
 
         VarMultiset(VarMultiset &&) = default;

--- a/include/PetriEngine/Colored/VarMultiset.h
+++ b/include/PetriEngine/Colored/VarMultiset.h
@@ -79,7 +79,7 @@ namespace PetriEngine::Colored {
 
         bool matchesType(const VarTuple &vt) const;
 
-        std::vector<const ColorType *> inferTypes(const VarTuple &vt);
+        static std::vector<const ColorType *> inferTypes(const VarTuple &vt);
 
         class Iterator {
         private:
@@ -94,11 +94,9 @@ namespace PetriEngine::Colored {
 
             bool operator!=(Iterator &other);
 
-            Iterator &operator++();
+            Iterator &operator++();;
 
-            std::pair<const std::vector<const Variable *>, const uint32_t &> operator++(int);
-
-            std::pair<const std::vector<const Variable *>, const uint32_t &> operator*();
+            std::pair<const VarTuple, const uint32_t &> operator*();
         };
     };
 }

--- a/include/PetriEngine/Colored/VarMultiset.h
+++ b/include/PetriEngine/Colored/VarMultiset.h
@@ -1,0 +1,54 @@
+/*
+ * Authors:
+ *      Nicolaj Østerby Jensen
+ *      Jesper Adriaan van Diepen
+ *      Mathias Mehl Sørensen
+ */
+
+#ifndef VERIFYPN_VARMULTISET_H
+#define VERIFYPN_VARMULTISET_H
+
+#include <vector>
+#include <cstdint>
+#include "Colors.h"
+
+namespace PetriEngine::Colored {
+    class VarMultiset {
+    private:
+        typedef std::vector<std::pair<const Variable*, uint32_t>> Internal;
+
+        Internal _set;
+        const ColorType* _type;
+    public:
+        VarMultiset() : _set(), _type(nullptr) {};
+        VarMultiset(const ColorType* type) : _set(), _type(type) {};
+        VarMultiset(const VarMultiset&) = default;
+        VarMultiset(VarMultiset&&) = default;
+        VarMultiset(const Variable*, uint32_t);
+        ~VarMultiset() = default;
+
+        VarMultiset& operator=(const VarMultiset&) = default;
+        VarMultiset& operator=(VarMultiset&&) = default;
+
+        VarMultiset operator+ (const VarMultiset& other) const;
+        VarMultiset operator- (const VarMultiset& other) const;
+        VarMultiset operator* (uint32_t scalar) const;
+        void operator+= (const VarMultiset& other);
+        void operator-= (const VarMultiset& other);
+        void operator*= (uint32_t scalar);
+        uint32_t operator[] (const Variable* color) const;
+        uint32_t& operator[] (const Variable* color);
+
+        bool empty() const {
+            return size() == 0;
+        };
+
+        size_t size() const;
+
+        size_t distinctSize() const {
+            return _set.size();
+        }
+    };
+}
+
+#endif //VERIFYPN_VARMULTISET_H

--- a/include/PetriEngine/Colored/VarMultiset.h
+++ b/include/PetriEngine/Colored/VarMultiset.h
@@ -15,29 +15,50 @@
 namespace PetriEngine::Colored {
     class VarMultiset {
     private:
-        typedef std::vector<std::pair<const Variable*, uint32_t>> Internal;
+        class Iterator;
+
+        typedef std::vector<std::pair<const Variable *, uint32_t>> Internal;
 
         Internal _set;
-        const ColorType* _type;
+        const ColorType *_type;
     public:
         VarMultiset() : _set(), _type(nullptr) {};
-        VarMultiset(const ColorType* type) : _set(), _type(type) {};
-        VarMultiset(const VarMultiset&) = default;
-        VarMultiset(VarMultiset&&) = default;
-        VarMultiset(const Variable*, uint32_t);
+
+        VarMultiset(const ColorType *type) : _set(), _type(type) {};
+
+        VarMultiset(const VarMultiset &) = default;
+
+        VarMultiset(VarMultiset &&) = default;
+
+        VarMultiset(const Variable *, uint32_t);
+
         ~VarMultiset() = default;
 
-        VarMultiset& operator=(const VarMultiset&) = default;
-        VarMultiset& operator=(VarMultiset&&) = default;
+        Iterator begin() const;
 
-        VarMultiset operator+ (const VarMultiset& other) const;
-        VarMultiset operator- (const VarMultiset& other) const;
-        VarMultiset operator* (uint32_t scalar) const;
-        void operator+= (const VarMultiset& other);
-        void operator-= (const VarMultiset& other);
-        void operator*= (uint32_t scalar);
-        uint32_t operator[] (const Variable* color) const;
-        uint32_t& operator[] (const Variable* color);
+        Iterator end() const;
+
+        VarMultiset &operator=(const VarMultiset &) = default;
+
+        VarMultiset &operator=(VarMultiset &&) = default;
+
+        VarMultiset operator+(const VarMultiset &other) const;
+
+        VarMultiset operator-(const VarMultiset &other) const;
+
+        VarMultiset operator*(uint32_t scalar) const;
+
+        void operator+=(const VarMultiset &other);
+
+        void operator-=(const VarMultiset &other);
+
+        void operator*=(uint32_t scalar);
+
+        uint32_t operator[](const Variable *color) const;
+
+        uint32_t &operator[](const Variable *color);
+
+        bool isSubsetOf(const VarMultiset &other) const;
 
         bool empty() const {
             return size() == 0;
@@ -48,6 +69,29 @@ namespace PetriEngine::Colored {
         size_t distinctSize() const {
             return _set.size();
         }
+
+        std::string toString() const;
+
+    private:
+        class Iterator {
+        private:
+            const VarMultiset *_ms;
+            size_t _index;
+
+        public:
+            Iterator(const VarMultiset *ms, size_t index)
+                    : _ms(ms), _index(index) {}
+
+            bool operator==(Iterator &other);
+
+            bool operator!=(Iterator &other);
+
+            Iterator &operator++();
+
+            std::pair<const Variable *, const uint32_t &> operator++(int);
+
+            std::pair<const Variable *, const uint32_t &> operator*();
+        };
     };
 }
 

--- a/src/PetriEngine/Colored/ArcVarMultisetVisitor.cpp
+++ b/src/PetriEngine/Colored/ArcVarMultisetVisitor.cpp
@@ -1,0 +1,42 @@
+/*
+ * Authors:
+ *      Nicolaj Østerby Jensen
+ *      Jesper Adriaan van Diepen
+ *      Mathias Mehl Sørensen
+ */
+
+#include "PetriEngine/Colored/ArcVarMultisetVisitor.h"
+
+namespace PetriEngine::Colored {
+    void ArcVarMultisetVisitor::accept(const VariableExpression * e) {
+        _mres = VarMultiset(e->variable(), 1);
+    }
+
+    void ArcVarMultisetVisitor::accept(const TupleExpression * e) {
+        // TODO Fuck
+    }
+
+    void ArcVarMultisetVisitor::accept(const NumberOfExpression * e) {
+        // TODO
+        _mres *= e->number();
+    }
+
+    void ArcVarMultisetVisitor::accept(const AddExpression * e) {
+        VarMultiset ms;
+        for (const auto& expr : *e) {
+            expr->visit(*this);
+            ms += _mres;
+        }
+        _mres = ms;
+    }
+
+    void ArcVarMultisetVisitor::accept(const ScalarProductExpression * e) {
+        // TODO
+    }
+
+    VarMultiset ArcVarMultisetVisitor::extract(const ArcExpression &e) {
+        ArcVarMultisetVisitor v;
+        e.visit(v);
+        return v._mres;
+    }
+}

--- a/src/PetriEngine/Colored/ArcVarMultisetVisitor.cpp
+++ b/src/PetriEngine/Colored/ArcVarMultisetVisitor.cpp
@@ -50,9 +50,9 @@ namespace PetriEngine::Colored {
         _msRes *= e->scalar();
     }
 
-    VarMultiset ArcVarMultisetVisitor::extract(const ArcExpression &e) {
+    std::optional<VarMultiset> ArcVarMultisetVisitor::extract(const ArcExpression &e) {
         ArcVarMultisetVisitor v;
         e.visit(v);
-        return v._msRes;
+        return v._ok ? std::optional { v._msRes } : std::nullopt;
     }
 }

--- a/src/PetriEngine/Colored/CMakeLists.txt
+++ b/src/PetriEngine/Colored/CMakeLists.txt
@@ -17,7 +17,8 @@ StablePlaceFinder.cpp
 ForwardFixedPoint.cpp
 VariableSymmetry.cpp
 Unfolder.cpp
-VarMultiset.cpp)
+VarMultiset.cpp
+ArcVarMultisetVisitor.cpp)
 
 target_link_libraries(Colored ColoredReduction)
 add_dependencies(Colored rapidxml-ext ptrie-ext glpk-ext)

--- a/src/PetriEngine/Colored/CMakeLists.txt
+++ b/src/PetriEngine/Colored/CMakeLists.txt
@@ -16,7 +16,8 @@ EvaluationVisitor.cpp
 StablePlaceFinder.cpp
 ForwardFixedPoint.cpp
 VariableSymmetry.cpp
-Unfolder.cpp)
+Unfolder.cpp
+VarMultiset.cpp)
 
 target_link_libraries(Colored ColoredReduction)
 add_dependencies(Colored rapidxml-ext ptrie-ext glpk-ext)

--- a/src/PetriEngine/Colored/VarMultiset.cpp
+++ b/src/PetriEngine/Colored/VarMultiset.cpp
@@ -8,23 +8,32 @@
 #include "PetriEngine/Colored/VarMultiset.h"
 
 namespace PetriEngine::Colored {
-    VarMultiset::VarMultiset(const PetriEngine::Colored::Variable * v, const uint32_t multiplicity) : _set(), _type(v->colorType) {
+    VarMultiset::VarMultiset(const PetriEngine::Colored::Variable *v, const uint32_t multiplicity)
+            : _set(), _type(v->colorType) {
         _set.emplace_back(v, multiplicity);
     }
 
-    VarMultiset VarMultiset::operator +(const VarMultiset& other) const {
+    VarMultiset::Iterator VarMultiset::begin() const {
+        return Iterator(this, 0);
+    }
+
+    VarMultiset::Iterator VarMultiset::end() const {
+        return Iterator(this, _set.size());
+    }
+
+    VarMultiset VarMultiset::operator+(const VarMultiset &other) const {
         VarMultiset ms(*this);
         ms += other;
         return ms;
     }
 
-    VarMultiset VarMultiset::operator -(const VarMultiset& other) const {
+    VarMultiset VarMultiset::operator-(const VarMultiset &other) const {
         VarMultiset ms(*this);
         ms -= other;
         return ms;
     }
 
-    VarMultiset VarMultiset::operator *(uint32_t scalar) const {
+    VarMultiset VarMultiset::operator*(uint32_t scalar) const {
         VarMultiset ms(*this);
         ms *= scalar;
         return ms;
@@ -34,7 +43,7 @@ namespace PetriEngine::Colored {
         if (_type == nullptr) _type = other._type;
         if (_type != other._type)
             throw base_error("You cannot compare variable multisets of different types");
-        for (auto pair : other._set) {
+        for (auto pair: other._set) {
             (*this)[pair.first] += pair.second;
         }
     }
@@ -43,32 +52,32 @@ namespace PetriEngine::Colored {
         if (_type == nullptr) _type = other._type;
         if (other._type != nullptr && _type != other._type)
             throw base_error("You cannot add multisets over different sets");
-        for (auto pair : _set) {
+        for (auto pair: _set) {
             (*this)[pair.first] = std::min<uint32_t>(pair.second - other[pair.first], 0); // min because underflow
         }
     }
 
     void VarMultiset::operator*=(uint32_t scalar) {
-        for (auto& pair : _set) {
+        for (auto &pair: _set) {
             pair.second *= scalar;
         }
     }
 
-    uint32_t VarMultiset::operator [](const Variable* var) const {
+    uint32_t VarMultiset::operator[](const Variable *var) const {
         if (_type == nullptr || _type == var->colorType) {
-            for (auto pair : _set) {
+            for (auto pair: _set) {
                 if (pair.first == var) return pair.second;
             }
         }
         return 0;
     }
 
-    uint32_t& VarMultiset::operator [](const Variable* var) {
+    uint32_t &VarMultiset::operator[](const Variable *var) {
         if (_type == nullptr) _type = var->colorType;
         if (_type != var->colorType) {
             throw base_error("You cannot access a multiset with a variable from a different color type");
         }
-        for (auto & i : _set) {
+        for (auto &i: _set) {
             if (i.first == var) return i.second;
         }
         _set.emplace_back(var, 0);
@@ -77,9 +86,45 @@ namespace PetriEngine::Colored {
 
     size_t VarMultiset::size() const {
         size_t res = 0;
-        for (auto pair : _set) {
+        for (auto pair: _set) {
             res += pair.second;
         }
         return res;
+    }
+
+    bool VarMultiset::isSubsetOf(const VarMultiset &other) const {
+        VarMultiset thisMinusOther(*this);
+        thisMinusOther -= other;
+        VarMultiset otherMinusThis(other);
+        otherMinusThis -= *this;
+        return thisMinusOther.empty() && !otherMinusThis.empty();
+    }
+
+    std::string VarMultiset::toString() const {
+        std::ostringstream oss;
+        for (size_t i = 0; i < _set.size(); ++i) {
+            oss << _set[i].second << "'" << _set[i].first->name;
+            if (i < _set.size() - 1) {
+                oss << " + ";
+            }
+        }
+        return oss.str();
+    }
+
+    bool VarMultiset::Iterator::operator==(VarMultiset::Iterator &other) {
+        return _ms == other._ms && _index == other._index;
+    }
+
+    bool VarMultiset::Iterator::operator!=(VarMultiset::Iterator &other) {
+        return !(*this == other);
+    }
+
+    VarMultiset::Iterator &VarMultiset::Iterator::operator++() {
+        ++_index;
+        return *this;
+    }
+
+    std::pair<const Variable *, const uint32_t &> VarMultiset::Iterator::operator*() {
+        return _ms->_set[_index];
     }
 }

--- a/src/PetriEngine/Colored/VarMultiset.cpp
+++ b/src/PetriEngine/Colored/VarMultiset.cpp
@@ -96,7 +96,15 @@ namespace PetriEngine::Colored {
     std::string VarMultiset::toString() const {
         std::ostringstream oss;
         for (size_t i = 0; i < _set.size(); ++i) {
-            oss << _set[i].second << "'" << _set[i].first->name;
+            auto &entry = _set[i];
+            oss << _set[i].second << "'(";
+            for (int j = 0; j < entry.first.size(); ++j) {
+                oss << entry.first[j]->name;
+                if (j < entry.first.size() - 1) {
+                    oss << ", ";
+                }
+            }
+            oss << ")";
             if (i < _set.size() - 1) {
                 oss << " + ";
             }
@@ -104,18 +112,11 @@ namespace PetriEngine::Colored {
         return oss.str();
     }
 
-    bool VarMultiset::matchesType(const std::vector<const Variable *> &vartuple) const {
-#ifndef NDEBUG
-        if (_ptype != nullptr) {
-            assert(vartuple.size() == _ptype->productSize());
-            for (int i = 0; i < vartuple.size(); ++i) {
-
-            }
-            return true;
+    bool VarMultiset::matchesType(const VarTuple &vt) const {
+        if (_types.size() != vt.size()) return false;
+        for (int i = 0; i < _types.size(); ++i) {
+            if (_types[i] != vt[i]->colorType) return false;
         }
-        assert(vartuple.size() == 1);
-        assert(vartuple[0]->colorType == _type);
-#endif
         return true;
     }
 
@@ -140,7 +141,7 @@ namespace PetriEngine::Colored {
         return *this;
     }
 
-    std::pair<const Variable *, const uint32_t &> VarMultiset::Iterator::operator*() {
+    std::pair<const std::vector<const Variable *>, const uint32_t &> VarMultiset::Iterator::operator*() {
         return _ms->_set[_index];
     }
 }

--- a/src/PetriEngine/Colored/VarMultiset.cpp
+++ b/src/PetriEngine/Colored/VarMultiset.cpp
@@ -1,0 +1,85 @@
+/*
+ * Authors:
+ *      Nicolaj Østerby Jensen
+ *      Jesper Adriaan van Diepen
+ *      Mathias Mehl Sørensen
+ */
+
+#include "PetriEngine/Colored/VarMultiset.h"
+
+namespace PetriEngine::Colored {
+    VarMultiset::VarMultiset(const PetriEngine::Colored::Variable * v, const uint32_t multiplicity) : _set(), _type(v->colorType) {
+        _set.emplace_back(v, multiplicity);
+    }
+
+    VarMultiset VarMultiset::operator +(const VarMultiset& other) const {
+        VarMultiset ms(*this);
+        ms += other;
+        return ms;
+    }
+
+    VarMultiset VarMultiset::operator -(const VarMultiset& other) const {
+        VarMultiset ms(*this);
+        ms -= other;
+        return ms;
+    }
+
+    VarMultiset VarMultiset::operator *(uint32_t scalar) const {
+        VarMultiset ms(*this);
+        ms *= scalar;
+        return ms;
+    }
+
+    void VarMultiset::operator+=(const VarMultiset &other) {
+        if (_type == nullptr) _type = other._type;
+        if (_type != other._type)
+            throw base_error("You cannot compare variable multisets of different types");
+        for (auto pair : other._set) {
+            (*this)[pair.first] += pair.second;
+        }
+    }
+
+    void VarMultiset::operator-=(const VarMultiset &other) {
+        if (_type == nullptr) _type = other._type;
+        if (other._type != nullptr && _type != other._type)
+            throw base_error("You cannot add multisets over different sets");
+        for (auto pair : _set) {
+            (*this)[pair.first] = std::min<uint32_t>(pair.second - other[pair.first], 0); // min because underflow
+        }
+    }
+
+    void VarMultiset::operator*=(uint32_t scalar) {
+        for (auto& pair : _set) {
+            pair.second *= scalar;
+        }
+    }
+
+    uint32_t VarMultiset::operator [](const Variable* var) const {
+        if (_type == nullptr || _type == var->colorType) {
+            for (auto pair : _set) {
+                if (pair.first == var) return pair.second;
+            }
+        }
+        return 0;
+    }
+
+    uint32_t& VarMultiset::operator [](const Variable* var) {
+        if (_type == nullptr) _type = var->colorType;
+        if (_type != var->colorType) {
+            throw base_error("You cannot access a multiset with a variable from a different color type");
+        }
+        for (auto & i : _set) {
+            if (i.first == var) return i.second;
+        }
+        _set.emplace_back(var, 0);
+        return _set.back().second;
+    }
+
+    size_t VarMultiset::size() const {
+        size_t res = 0;
+        for (auto pair : _set) {
+            res += pair.second;
+        }
+        return res;
+    }
+}

--- a/src/PetriEngine/Colored/VarMultiset.cpp
+++ b/src/PetriEngine/Colored/VarMultiset.cpp
@@ -8,6 +8,10 @@
 #include "PetriEngine/Colored/VarMultiset.h"
 
 namespace PetriEngine::Colored {
+    VarMultiset::VarMultiset(const VarMultiset::VarTuple &vars, uint32_t multiplicity) : _set(), _types(inferTypes(vars)) {
+        (*this)[vars] = multiplicity;
+    }
+
     VarMultiset::Iterator VarMultiset::begin() const {
         return Iterator(this, 0);
     }


### PR DESCRIPTION
The VarMultiset is a multiset of tuples of variables. It will be used to hold the variables of arcs. The ArvVarMultisetVisitor can be used to turn an ArcExpression into a VarMultiset. Both are currently unused, but they will be used in Parallel Places and Parallel Transition rules as well as in the normal form.